### PR TITLE
Revise documentation

### DIFF
--- a/documentation/metadata-guide.md
+++ b/documentation/metadata-guide.md
@@ -8,8 +8,10 @@
   this fixes rendering of tables and other document formatting on GitHub
 -->
 
-*These guidelines are based on the work of the Bibliotheca Philadelphiensis Project.
-The original Bibliotheca Philadelphiensis documentation may be viewed [here](https://docs.google.com/document/d/1zeUkzmy-3kpK-egqko_IHWZJ992qEnMcgIdzF6Syz4M/edit?usp=sharing)*
+*These guidelines are based on the work of the Bibliotheca
+Philadelphiensis Project. The original Bibliotheca Philadelphiensis
+documentation may be viewed
+[here](https://docs.google.com/document/d/1zeUkzmy-3kpK-egqko_IHWZJ992qEnMcgIdzF6Syz4M/edit?usp=sharing)*
 
 # Spreadsheet Metadata Guidelines
 
@@ -29,8 +31,8 @@ with a semi-colon.
 
 Required
 
-**Description:** Name of the project liaison at a partner
-institution; consistent for all manuscripts from a single institution.
+**Description:** Name of the project liaison at a partner institution;
+consistent for all manuscripts from a single institution.
 
 ## Administrative Contact Email
 
@@ -59,7 +61,8 @@ Optional
 
 **MARC Location:** Possibly 852 subfield e
 
-**Description:** Country of the holding library; United States for all partner institutions.
+**Description:** Country of the holding library; United States for all
+partner institutions.
 
 ## Repository City
 
@@ -156,12 +159,11 @@ be supplied from LC/OCLC.
 Optional, Repeatable
 
 **Description:** For authors in the LC NAF, give the URI from
-<http://id.loc.gov/authorities/names.html>;
-for creators in VIAF give the permalink from
-<http://viaf.org/>;
-unlikely to appear in dealer or narrative library descriptions, probably
-needs to be supplied. If you have verified that the author name does not
-have an authorized form in LC NAF or VIAF, enter N/A.
+<http://id.loc.gov/authorities/names.html>; for creators in VIAF give
+the permalink from <http://viaf.org/>; unlikely to appear in dealer or
+narrative library descriptions, probably needs to be supplied. If you
+have verified that the author name does not have an authorized form in
+LC NAF or VIAF, enter N/A.
 
 ## Translator Name
 
@@ -180,12 +182,11 @@ descriptions, probably needs to be supplied from LC/OCLC.
 Optional, Repeatable
 
 **Description:** For translators in the LC NAF, give the URI from
-<http://id.loc.gov/authorities/names.html>;
-for translators in VIAF give the permalink from
-<http://viaf.org/>;
-unlikely to appear in dealer or narrative library descriptions, probably
-needs to be supplied. If you have verified that the translator name does
-not have an authorized form in LC NAF or VIAF, enter N/A.
+<http://id.loc.gov/authorities/names.html>; for translators in VIAF give
+the permalink from <http://viaf.org/>; unlikely to appear in dealer or
+narrative library descriptions, probably needs to be supplied. If you
+have verified that the translator name does not have an authorized form
+in LC NAF or VIAF, enter N/A.
 
 ## Artist Name
 
@@ -205,14 +206,12 @@ probably needs to be supplied from LC/OCLC.
 Optional, Repeatable
 
 **Description:** For artists in ULAN, give the ID from
-<http://www.getty.edu/research/tools/vocabularies/ulan/>;
-for artists in LC NAF, give the URI from
-<http://id.loc.gov/authorities/names.html>;
-for artists in VIAF give the permalink from
-<http://viaf.org/>;
-unlikely to appear in dealer or narrative library descriptions, probably
-needs to be supplied. If you have verified that the artist name does not
-have an authorized form in ULAN, LC NAF, or VIAF, enter N/A.
+<http://www.getty.edu/research/tools/vocabularies/ulan/>; for artists in
+LC NAF, give the URI from <http://id.loc.gov/authorities/names.html>;
+for artists in VIAF give the permalink from <http://viaf.org/>; unlikely
+to appear in dealer or narrative library descriptions, probably needs to
+be supplied. If you have verified that the artist name does not have an
+authorized form in ULAN, LC NAF, or VIAF, enter N/A.
 
 ## Former Owner Name
 
@@ -232,12 +231,11 @@ from LC/OCLC.
 Optional, Repeatable
 
 **Description:** For former owners in the LC NAF, give the URI from
-<http://id.loc.gov/authorities/names.html>;
-for former owners in VIAF give the permalink from
-<http://viaf.org/>;
-unlikely to appear in dealer or narrative library descriptions, probably
-needs to be supplied. If you have verified that the former owner name
-does not have an authorized form in LC NAF or VIAF, enter N/A.
+<http://id.loc.gov/authorities/names.html>; for former owners in VIAF
+give the permalink from <http://viaf.org/>; unlikely to appear in dealer
+or narrative library descriptions, probably needs to be supplied. If you
+have verified that the former owner name does not have an authorized
+form in LC NAF or VIAF, enter N/A.
 
 ## Provenance
 
@@ -293,11 +291,11 @@ possibly 260 subfield c
 **Description:** Ending year for a manuscript completed over an extended
 period of time or the latest year of a section of a manuscript
 consisting of originally separate manuscripts copied at different times,
-with each section provided its own **Date (single)** or **Date (range)**;
-probably in the headings of a dealer or library description, otherwise
-in notes; if the range is given as a narrative phrase (see **Date
-(narrative)** below), supply an ending year here; enter as the year only
-without additional words.
+with each section provided its own **Date (single)** or **Date
+(range)**; probably in the headings of a dealer or library description,
+otherwise in notes; if the range is given as a narrative phrase (see
+**Date (narrative)** below), supply an ending year here; enter as the
+year only without additional words.
 
 ## Date (narrative)
 
@@ -567,7 +565,7 @@ in the following examples:
 > Philadelphia Museum of Art, *Leaves of Gold: Manuscript Illumination
 > from Philadelphia Collections*, edited by James R. Tanis
 > (Philadelphia: Philadelphia Museum of Art, 2001), pp. 102-103, no. 31.
->
+> 
 > Philip H. & A.S.W. Rosenbach Foundation Museum. *A Selection from Our
 > Shelves: Books, Manuscripts, and Drawings from the Philip H. & A.S.W.
 > Rosenbach Foundation Museum* (Philadelphia: Philip H. & A.S.W.
@@ -577,8 +575,8 @@ in the following examples:
 > Saint Louis: A Study of Styles* (Berkeley: University of California
 > Press, 1977), p. 82.
 > 
-> Branner, Robert, "The Johannes Grusch Atelier and the Continental
-> Origins of the William of Devon Painter," *Art Bulletin* 54, no. 1
+> Branner, Robert, “The Johannes Grusch Atelier and the Continental
+> Origins of the William of Devon Painter,” *Art Bulletin* 54, no. 1
 > (1972): p. 30 (article pp. 24-30).
 > 
 > Peterson, Elizabeth Anne, “The Textual Basis for Visual Errors in
@@ -586,12 +584,12 @@ in the following examples:
 > Production, Decoration and Use*, ed. Richard Gameson (Cambridge:
 > Cambridge University Press, 1994), pp. 182-83 (article pp. 177-204).
 > 
-> Zigrosser, Carl, "The Philip S. Collins Collection of Mediaeval
-> Illuminated Manuscripts," *Philadelphia Museum of Art Bulletin* 58,
+> Zigrosser, Carl, “The Philip S. Collins Collection of Mediaeval
+> Illuminated Manuscripts,” *Philadelphia Museum of Art Bulletin* 58,
 > no. 275 (Autumn 1962): pp. 20-21 (article pp. 3-34).
 > 
-> Gardiner, Henry G., "The Samuel S. White, 3rd, and Vera White
-> Collection," *Philadelphia Museum of Art Bulletin* 63, no. 296/297
+> Gardiner, Henry G., “The Samuel S. White, 3rd, and Vera White
+> Collection,” *Philadelphia Museum of Art Bulletin* 63, no. 296/297
 > (January 1, 1968): p. 118, no. 118 (article pp. 71-150).
 
 \[note that the page or page range where a manuscript is mentioned is
@@ -623,11 +621,9 @@ dealer or narrative library descriptions, may be supplied from LC/OCLC.
 Optional, Repeatable
 
 **Description:** For subjects in the LCNAF, give the URI from
-<http://id.loc.gov/authorities/names.html>;
-for creators in VIAF give the permalink from
-<http://viaf.org/>;
-unlikely to appear in dealer or narrative library descriptions, may be
-supplied.
+<http://id.loc.gov/authorities/names.html>; for creators in VIAF give
+the permalink from <http://viaf.org/>; unlikely to appear in dealer or
+narrative library descriptions, may be supplied.
 
 ## Subject: topical
 
@@ -644,9 +640,8 @@ from LC/OCLC.
 Optional, Repeatable
 
 **Description:** For subjects in LCSH, give the URI from
-<http://id.loc.gov/authorities/subjects.html>;
-unlikely to appear in this form in dealer or narrative library
-descriptions, may be supplied.
+<http://id.loc.gov/authorities/subjects.html>; unlikely to appear in
+this form in dealer or narrative library descriptions, may be supplied.
 
 ## Subject: geographic
 
@@ -663,9 +658,8 @@ supplied from LC/OCLC.
 Optional, Repeatable
 
 **Description:** For subjects in LCSH, give the URI from
-<http://id.loc.gov/authorities/subjects.html>;
-unlikely to appear in this form in dealer or narrative library
-descriptions, may be supplied.
+<http://id.loc.gov/authorities/subjects.html>; unlikely to appear in
+this form in dealer or narrative library descriptions, may be supplied.
 
 ## Subject: genre/form
 
@@ -675,22 +669,21 @@ Optional, Repeatable
 
 **Description:** Genre/form term as found in LCSH or Getty Art &
 Architecture Thesaurus
-<http://www.getty.edu/research/tools/vocabularies/aat/>;
-unlikely to appear in this form in dealer or narrative library
-descriptions, may be supplied.
+<http://www.getty.edu/research/tools/vocabularies/aat/>; unlikely to
+appear in this form in dealer or narrative library descriptions, may be
+supplied.
 
 ## Subject: genre/form URI
 
 Optional, Repeatable
 
 **Description:** For genre/form terms in LCSH, give the URI from
-<http://id.loc.gov/authorities/subjects.html>
-or
-<http://id.loc.gov/authorities/genreForms.html>;
-for genre/form terms in AAT, give the URI in the form
-<http://vocab.getty.edu/aat/> {AAT ID\#} (more information available at
-<http://vocab.getty.edu/>); unlikely to appear in this form in dealer or
-narrative library descriptions, may be supplied.
+<http://id.loc.gov/authorities/subjects.html> or
+<http://id.loc.gov/authorities/genreForms.html>; for genre/form terms in
+AAT, give the URI in the form <http://vocab.getty.edu/aat/> {AAT ID\#}
+(more information available at <http://vocab.getty.edu/>); unlikely to
+appear in this form in dealer or narrative library descriptions, may be
+supplied.
 
 ## Keyword
 

--- a/documentation/structural-metadata-guide.md
+++ b/documentation/structural-metadata-guide.md
@@ -8,8 +8,10 @@
   this fixes rendering of tables and other document formatting on GitHub
 -->
 
-*These guidelines are based on the work of the Bibliotheca Philadelphiensis Project.
-The original Bibliotheca Philadelphiensis documentation may be viewed [here](https://docs.google.com/document/d/1HzfYAgNuJaRKXcZ1rYE-0hS5_TxidWDNLN6X2cVFpAM/edit?usp=sharing)*
+*These guidelines are based on the work of the Bibliotheca
+Philadelphiensis Project. The original Bibliotheca Philadelphiensis
+documentation may be viewed
+[here](https://docs.google.com/document/d/1HzfYAgNuJaRKXcZ1rYE-0hS5_TxidWDNLN6X2cVFpAM/edit?usp=sharing)*
 
 # Structural Metadata Guidelines
 
@@ -68,8 +70,8 @@ Values next to BLANK tags will be ignored.
 
 ## DISPLAY PAGE
 
-Enter a **display page** value for each image.
-Typical values are supplied in the subsections below.
+Enter a **display page** value for each image. Typical values are
+supplied in the subsections below.
 
 ### External Structure
 
@@ -87,17 +89,17 @@ Front matter:
   - \[Flyleaf 1 recto\]
   - \[Flyleaf 1 verso\]
 
-Back matter: 
+Back matter:
 
   - \[Flyleaf 1 recto\]
   - \[Flyleaf 1 verso\]
   - Inside back cover
   - Back cover
 
-When flyleaves are numbered, identify the leaf as a flyleaf and add the folio number after,
-separated by a semicolon: 
+When flyleaves are numbered, identify the leaf as a flyleaf and add the
+folio number after, separated by a semicolon:
 
--  \[Flyleaf 1 recto; fol. 239\]
+  - \[Flyleaf 1 recto; fol. 239\]
 
 ## Text block (constituent leaves not including the flyleaves)
 
@@ -116,7 +118,7 @@ Leaves foliated or paginated and attached:
 
 <!-- I'm uncertain what the progression from Arabic to Roman to Alpha is supposed to signify. irc -->
 
-Leaves attached but not foliated/paginated: 
+Leaves attached but not foliated/paginated:
 
   - \[1r\]
   - \[1v\]
@@ -201,5 +203,5 @@ Multiple fragments or cuttings without identifiable recto/verso:
   - Loose leaf 2 Side 1
   - Loose leaf 2 Side 2
 
-If you have any questions about how to describe something not covered
-in these guidelines please contact Liz Hebbard (ehebbard@iu.edu).
+If you have any questions about how to describe something not covered in
+these guidelines please contact Liz Hebbard (ehebbard@iu.edu).

--- a/documentation/style-guide.md
+++ b/documentation/style-guide.md
@@ -8,40 +8,43 @@
   this fixes rendering of tables and other document formatting on GitHub
 -->
 
-*These guidelines are based on the work of the Bibliotheca Philadelphiensis Project.
-The original Bibliotheca Philadelphiensis documentation may be viewed [here](https://docs.google.com/document/d/1lID4BmrA87YebTJRmCebgB8mXANeOytEML_MV5n12fo/edit?usp=sharing)*
+*These guidelines are based on the work of the Bibliotheca
+Philadelphiensis Project. The original Bibliotheca Philadelphiensis
+documentation may be viewed
+[here](https://docs.google.com/document/d/1lID4BmrA87YebTJRmCebgB8mXANeOytEML_MV5n12fo/edit?usp=sharing)*
 
 # CATALOGUING GUIDELINES AND STANDARDS
 
-The purpose of the following guidelines is to insure consistency of style, terminology, format, and data type in
-cataloguing data and descriptions. Consistency here means regularity,
-predictability, uniformity, and “searchability.” Users of 
-this digitized catalogue should expect to find the same
-amount and type of data in each entry field, and in the same general
-order.
+The purpose of the following guidelines is to insure consistency of
+style, terminology, format, and data type in cataloguing data and
+descriptions. Consistency here means regularity, predictability,
+uniformity, and “searchability.” Users of this digitized catalogue
+should expect to find the same amount and type of data in each entry
+field, and in the same general order.
 
-Consistency in all fields is particularly important for manuscripts
-of the same title: Bible, Gospels, Missal, Lectionary, Book of Hours,
-etc.
+Consistency in all fields is particularly important for manuscripts of
+the same title: Bible, Gospels, Missal, Lectionary, Book of Hours, etc.
 
 For details on what information should be included in specific fields
-please refer to the [Spreadsheet Metadata Guidelines](https://github.com/sarahloleet/peripheralmss/blob/master/documentation/metadata-guide.md)
+please refer to the [Spreadsheet Metadata
+Guidelines](https://github.com/sarahloleet/peripheralmss/blob/master/documentation/metadata-guide.md)
 
 # GENERAL GUIDELINES
 
 ## Sentences and Fragments
+
 The **Description** field is the only entry field to be composed in full
-sentences (use present tense verbs).
-All other fields should be in phrases or fragments, except where the
-meaning becomes confusing and difficult to express without a full sentence.
+sentences (use present tense verbs). All other fields should be in
+phrases or fragments, except where the meaning becomes confusing and
+difficult to express without a full sentence.
 
 ## Capitalization, Spacing, Punctuation
 
 Capitalize the initial letter of all entries in all fields. Avoid using
-unnecessary abbreviations; do not abbreviate the word
-“Saint.” Single space (not double) between sentences.
+unnecessary abbreviations; do not abbreviate the word “Saint.” Single
+space (not double) between sentences.
 
-Punctuation follows American usage and goes inside quotation marks: “...
+Punctuation follows American usage and goes inside quotation marks: “…
 Gothic.” Period at end of full sentences only, not phrases or fragments
 (as here)
 
@@ -61,11 +64,11 @@ of red, white, and blue
 Use lower case for all but first word in a title: *A tainted mantle*
 (not *A Tainted Mantle*)
 
-An exception to this rule is that book types, e.g., Psalter,
-Lectionary, Book of Hours, Book of Hours Use of Rome, Missal etc. should
-always be capitalized in titles. This also applies to terms like
-Chronicle if it is used in the sense of it being that type of book, and
-not just a word in the title, e.g., Grandes Chroniques
+An exception to this rule is that book types, e.g., Psalter, Lectionary,
+Book of Hours, Book of Hours Use of Rome, Missal etc. should always be
+capitalized in titles. This also applies to terms like Chronicle if it
+is used in the sense of it being that type of book, and not just a word
+in the title, e.g., Grandes Chroniques
 
 If a slash or colon is part of a title, leave a space on either side: *A
 tainted mantle : Hercules and the classical tradition at the Carolingian
@@ -87,8 +90,8 @@ Spell out ordinal numbers: first, not 1<sup>st</sup> ; this also applies
 to centuries within text fields: the fourteenth century; a
 fourteenth-century manuscript
 
-An exception: in the date narrative field **only**, use the following format
-for a century date: 9<sup>th</sup> century
+An exception: in the date narrative field **only**, use the following
+format for a century date: 9<sup>th</sup> century
 
 Hyphenate a century only if it is an adjective: a tenth-century
 palimpsest (Otherwise: a palimpsest from the tenth century)
@@ -110,12 +113,12 @@ abbreviated, so spell out “Genesis,” not “Gen.”)
 
 Preferred abbreviation for folio: fol. (plural: fols.)
 
-There is a space between a folio abbreviation and a folio
-number: fol. 5r
+There is a space between a folio abbreviation and a folio number:
+fol. 5r
 
-Always include ‘r’ or ‘v’ with folio number, e.g., fols. 1r-3v,
-not 1-3v. When indicating a range over the recto/verso of a single
-folio: fol. 1r-v
+Always include ‘r’ or ‘v’ with folio number, e.g., fols. 1r-3v, not
+1-3v. When indicating a range over the recto/verso of a single folio:
+fol. 1r-v
 
 Preferred abbreviation for manuscript/manuscripts: Ms./Mss.
 
@@ -141,8 +144,8 @@ The text or writing on a book page: **written area**
   - acceptable alternatives: justification
   - *not* recommended: text block
 
-Book page/pages: **folio/s** (when foliated) or **page/s**
-(when paginated)
+Book page/pages: **folio/s** (when foliated) or **page/s** (when
+paginated)
 
   - acceptable alternative (for folio only): leaf/ves
 
@@ -157,16 +160,16 @@ A book’s decoration in general: **decoration, decorated**
   - acceptable alternatives: illumination, illuminated
   - *not* recommended: ornamentation, gilded
 
-A book’s text painting/s in general: **illustration,
-illustrated, miniature**
+A book’s text painting/s in general: **illustration, illustrated,
+miniature**
 
   - acceptable alternatives: painting, painted
 
-A book’s opening, full-page decoration without text:
-**illuminated** (or **illustrated) frontispiece**
+A book’s opening, full-page decoration without text: **illuminated** (or
+**illustrated) frontispiece**
 
-A book’s opening, full-page decoration including initial
-text: **illuminated incipit**
+A book’s opening, full-page decoration including initial text:
+**illuminated incipit**
 
 The space/s outside the written area: **margin/s**
 
@@ -179,8 +182,9 @@ great, elegant, clear) should be used sparingly throughout.
 
 # ITEM-LEVEL FIELDS
 
-Fields are listed in order of appearance in sheet 1 of the template spreadsheet.
-For further details see the [Spreadsheet Metadata Guidelines](https://github.com/sarahloleet/peripheralmss/blob/master/documentation/metadata-guide.md)
+Fields are listed in order of appearance in sheet 1 of the template
+spreadsheet. For further details see the [Spreadsheet Metadata
+Guidelines](https://github.com/sarahloleet/peripheralmss/blob/master/documentation/metadata-guide.md)
 
 ## Repository Country:
 
@@ -335,7 +339,8 @@ names are provided for reference, do not include them in the field:
   - cat \[Catalan\]
   - spa \[Spanish\]
 
-A fuller list of language codes is posted [here](https://github.com/sarahloleet/peripheralmss/blob/master/documentation/language-codes.csv).
+A fuller list of language codes is posted
+[here](https://github.com/sarahloleet/peripheralmss/blob/master/documentation/language-codes.csv).
 
 ## Foliation/Pagination:
 
@@ -384,7 +389,8 @@ collation formula/description in this field, please contact Dot.
   - **Make a model in the Collation Modeler**: model created
   - **Collation formula generation from model**: \[paste formula here\]
 -->
-If the collation cannot be determined, enter 'Structure Uncertain.'
+
+If the collation cannot be determined, enter ‘Structure Uncertain.’
 
 If you can determine part of the collation, but not the entire thing,
 you can also describe the collation as best you can and this will be
@@ -401,17 +407,17 @@ preferring the terms listed below if applicable.
   - Half-Uncial
   - Caroline Minuscule
   - Protogothic
-  - Gothic--textualis quadrata (consistent application of feet and
+  - Gothic–textualis quadrata (consistent application of feet and biting
+    of curves)
+  - Gothic–textualis semi-quadrata (inconsistent application of feet and
     biting of curves)
-  - Gothic--textualis semi-quadrata (inconsistent application of feet
-    and biting of curves)
-  - Gothic--textualis (everything below semi-quadrata; for Gothic with
+  - Gothic–textualis (everything below semi-quadrata; for Gothic with
     single-compartment *a*, sometimes called semitextualis, add a note:
-    “Gothic--textualis; single-compartment *a*”)
-  - Gothic--rotunda (round Italian textualis, not Brownian rotunda,
-    which is English with rounded-off minims)
-  - Gothic--anglicana
-  - Gothic--cursiva
+    “Gothic–textualis; single-compartment *a*”)
+  - Gothic–rotunda (round Italian textualis, not Brownian rotunda, which
+    is English with rounded-off minims)
+  - Gothic–anglicana
+  - Gothic–cursiva
   - Littera bononiensis
   - Secretary
   - Bâtarde
@@ -425,7 +431,7 @@ preferring the terms listed below if applicable.
 If the scribe is identifiable, include the scribe’s name, preceded by
 “Scribe:” For example, “Scribe: Thomas Hoccleve”.
 
-## Musical notation: 
+## Musical notation:
 
 If notation is present, describe it here.
 <!-- This field is our addition, not yet in the Google Sheet template -->
@@ -453,19 +459,26 @@ into individual cells.
 
 ## Related resource:
 
-See the Spreadsheet style guide. 
+See the Spreadsheet style guide.
 
 ## Keywords
 
-Keywords are listed [here](https://github.com/sarahloleet/peripheralmss/blob/master/documentation/keywords.csv).
-There are seven groups: Book Type, Century, Culture, Descriptive term, Geography, Subject, and Other.
+Keywords are listed
+[here](https://github.com/sarahloleet/peripheralmss/blob/master/documentation/keywords.csv).
+There are seven groups: Book Type, Century, Culture, Descriptive term,
+Geography, Subject, and Other.
 
-Add one keyword per column. You should be able to add at least one from Book Type, Century, Culture, and Geography. Add Descriptive Terms, Subjects, and Others as relevant.
-Copy and paste terms to avoid misspellings.
+Add one keyword per column. You should be able to add at least one from
+Book Type, Century, Culture, and Geography. Add Descriptive Terms,
+Subjects, and Others as relevant. Copy and paste terms to avoid
+misspellings.
 
-Keywords are to help users find the books. So consider what terms a user might select to try to find this book or a book like it, in addition to considering which terms apply to this book.
+Keywords are to help users find the books. So consider what terms a user
+might select to try to find this book or a book like it, in addition to
+considering which terms apply to this book.
 
-If you want to add a new term email the group (Liz, Michelle, Sarah, and Ian) to explain the need and we’ll deliberate.
+If you want to add a new term email the group (Liz, Michelle, Sarah, and
+Ian) to explain the need and we’ll deliberate.
 
 # PAGE-LEVEL FIELDS
 


### PR DESCRIPTION
See the first commit (9a86c63913e66a001e101e520632621cdddc695a) for a full change log. 

Looking ahead, I am inclined to move all the field-specific instructions in `style-guide.md` to the other two guides. This would remove duplication of instructions and remove the ambiguity about where to look for guidance on a given field. Following this change, the structure would be as follows: 

- For general instruction in style and usage, see the Style Guide. 
- For instruction on Item-level metadata fields (Sheet 1 of Google Sheet), see the Metadata Guide.
- For instruction on Page-level metadata fields (Sheet 2 of the Google Sheet), see the Structural Metadata Guide.

What do you think?